### PR TITLE
Add VS Code Extensions Section to Resources Page

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -65,6 +65,73 @@
           </li>
         </ul>
       </div>
+
+      <!-- VS Code Extensions  -->
+      <section>
+        <h2>VS Code Extensions</h2>
+        <ul>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=GitHub.copilot"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub Copilot
+            </a>
+            - AI pair programmer that helps write code faster.
+          </li>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Material Icon Theme
+            </a>
+            - Offers visually appealing icons for better code organization.
+          </li>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Prettier - Code Formatter
+            </a>
+            - An opinionated code formatter for consistent code style.
+          </li>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=ChakrounAnas.turbo-console-log"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Turbo Console Log
+            </a>
+            - Automates the process of writing meaningful log messages.
+          </li>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=naumovs.color-highlight"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Color Highlight
+            </a>
+            - Styles CSS/web color codes directly in the document.
+          </li>
+          <li>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Material Theme
+            </a>
+            - Provides elegant and customizable themes for the editor.
+          </li>
+        </ul>
+      </section>
     </main>
 
     <script src="main.js" type="module"></script>


### PR DESCRIPTION
## Changes Made

- Updated the `Resources` page to include a new section titled "VS Code Extensions."
- Listed six of my favorite VS Code extensions, each with a brief description and a link to their marketplace page.

This is in response to Issue #8  on adding more content to the 'Resources' page.

Thank you!
