### PR TITLE
Added links about tech articles for the 'Home' page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
             <img src="images/coffee.jpg" alt="A cup of coffee seen from above and with coffee beans around it" />
         </div>
         
+        <div id="feed">
+            <h2>Latest Technology News and articles</h2>
+        </div>
+
         <script src="main.js" type="module"></script>
     </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,15 @@
+const feed = document.getElementById('feed')
+
+fetch('https://newsdata.io/api/1/news?apikey=pub_37020dad134a463f0666e9f1a5eba6e8b2a34&q=coding%20%20AND%20computer&language=en&category=technology')
+.then(res => res.json())
+.then(data => {
+    const articles = data.results.map(article => {
+        return (
+        `<a href=${article.link} target="_blank">
+            <h4>${article.title}</h4>
+        </a>`
+        )
+    })
+    feed.innerHTML += articles.join('')
+})
+


### PR DESCRIPTION
I fetched the news and articles data from newsdata.io, just added the links to the actual articles as it was not possible to put a little description about each article because some information was available only with a paid subscription